### PR TITLE
various changes. nice title

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,13 @@ edition = "2021"
 [dependencies]
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1", features = ["full"] }
-tracing = "0.1.37"
-tracing-subscriber = "0.3.17"
-hyper-rustls = "0.23.0"
+hyper-rustls = { version = "0.24", features = ["http2"] }
+rustls = { version = "0.21", features = ["dangerous_configuration"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+rand = "0.8"
+
+[profile.release]
+opt-level = 3
+lto = true
+codegen-units = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
+use hyper::body::to_bytes;
 use hyper::{
-    body::to_bytes,
     service::{make_service_fn, service_fn},
     Body, Client, Request, Response, Server, Uri, StatusCode,
 };
@@ -179,7 +179,15 @@ async fn proxy_handler(
                 let status = resp.status();
                 info!("Response from S3: status {}", status);
                 debug!("Response headers: {:?}", resp.headers());
-                return Ok(resp);
+                
+                // Read the entire response body
+                let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+                
+                // Create a new response with the read body
+                return Ok(Response::builder()
+                    .status(status)
+                    .body(Body::from(body_bytes))
+                    .unwrap());
             }
             Ok(Err(e)) => {
                 error!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-
 use hyper::body::to_bytes;
 use hyper::{
     service::{make_service_fn, service_fn},

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,46 +1,88 @@
+
+use hyper::body::to_bytes;
 use hyper::{
     service::{make_service_fn, service_fn},
     Body, Client, Request, Response, Server, Uri,
 };
 use hyper_rustls::HttpsConnectorBuilder;
+use rustls::{client::{ServerCertVerifier, ServerCertVerified}, ServerName};
 use std::convert::Infallible;
 use std::env;
 use std::net::SocketAddr;
-use std::time::Instant;
-use tracing::{debug, error, info};
-use tracing_subscriber::FmtSubscriber;
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime};
+use tokio::time::timeout;
+use tracing::{debug, error, info, instrument, warn};
+use tracing_subscriber::{FmtSubscriber, EnvFilter};
+use rand::Rng;
+
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_RETRIES: u32 = 3;
+
+struct NoVerifier;
+
+impl ServerCertVerifier for NoVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::Certificate,
+        _intermediates: &[rustls::Certificate],
+        _server_name: &ServerName,
+        _scts: &mut dyn Iterator<Item = &[u8]>,
+        _ocsp_response: &[u8],
+        _now: SystemTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+}
 
 #[tokio::main]
-async fn main() {
-    println!("Print statement to stdout - starting s3-proxy");
-    FmtSubscriber::builder()
-        .with_max_level(tracing::Level::DEBUG)
-        .init();
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing with debug level
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(
+            EnvFilter::from_default_env()
+                .add_directive("s3_proxy=debug".parse().unwrap())
+                .add_directive("hyper=debug".parse().unwrap())
+                .add_directive("hyper_rustls=debug".parse().unwrap())
+        )
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("setting default subscriber failed");
 
     info!("Starting s3-proxy");
 
     let s3_url = env::var("S3_URL").expect("S3_URL environment variable not set");
     info!("S3_URL set to {}", s3_url);
 
-    let s3_base_uri = match s3_url.parse::<Uri>() {
-        Ok(uri) => {
-            info!("Parsed S3_URL successfully");
-            uri
-        }
-        Err(e) => {
-            error!("Invalid S3_URL: {}", e);
-            std::process::exit(1);
-        }
-    };
+    let s3_base_uri = s3_url.parse::<Uri>().map_err(|e| {
+        error!("Invalid S3_URL: {}", e);
+        e
+    })?;
 
-    let addr = ([0, 0, 0, 0], 8090).into();
+    let addr: SocketAddr = ([0, 0, 0, 0], 8092).into();
+
+    // Create HTTPS client with certificate verification disabled (for testing only)
+    let https = HttpsConnectorBuilder::new()
+        .with_tls_config(
+            rustls::ClientConfig::builder()
+                .with_safe_defaults()
+                .with_custom_certificate_verifier(Arc::new(NoVerifier))
+                .with_no_client_auth()
+        )
+        .https_only()
+        .enable_http1()
+        .build();
+
+    let client = Arc::new(Client::builder().build::<_, hyper::Body>(https));
 
     let make_svc = make_service_fn(move |conn: &hyper::server::conn::AddrStream| {
         let s3_base_uri = s3_base_uri.clone();
         let remote_addr = conn.remote_addr();
+        let client = Arc::clone(&client);
         async move {
             Ok::<_, Infallible>(service_fn(move |req| {
-                proxy_handler(req, s3_base_uri.clone(), remote_addr)
+                handle_request(req, s3_base_uri.clone(), remote_addr, Arc::clone(&client))
             }))
         }
     });
@@ -49,18 +91,38 @@ async fn main() {
 
     info!("Listening on http://{}", addr);
 
-    if let Err(e) = server.await {
-        error!("Server error: {}", e);
+    server.await?;
+
+    Ok(())
+}
+
+#[instrument(skip(req, client))]
+async fn handle_request(
+    req: Request<Body>,
+    s3_base_uri: Uri,
+    remote_addr: SocketAddr,
+    client: Arc<Client<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>>,
+) -> Result<Response<Body>, hyper::Error> {
+    if req.uri().path() == "/healthz" {
+        return Ok(Response::new(Body::from("OK")));
     }
+
+    let start = Instant::now();
+
+    let result = proxy_handler(req, s3_base_uri, remote_addr, client).await;
+
+    let duration = start.elapsed();
+    debug!("Request duration: {:?}", duration);
+
+    result
 }
 
 async fn proxy_handler(
-    mut req: Request<Body>,
+    req: Request<Body>,
     s3_base_uri: Uri,
     remote_addr: SocketAddr,
+    client: Arc<Client<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>>,
 ) -> Result<Response<Body>, hyper::Error> {
-    let start = Instant::now();
-
     info!(
         "Received request from {}: {} {}",
         remote_addr,
@@ -68,53 +130,91 @@ async fn proxy_handler(
         req.uri()
     );
 
-    let https = HttpsConnectorBuilder::new()
-        .with_native_roots()
-        .https_only()
-        .enable_http1()
-        .build();
-    let client = Client::builder().build::<_, hyper::Body>(https);
+    if !is_valid_s3_request(&req) {
+        warn!("Invalid S3 request received");
+        return Ok(Response::builder()
+            .status(hyper::StatusCode::BAD_REQUEST)
+            .body(Body::from("Invalid S3 request"))
+            .unwrap());
+    }
 
-    let mut parts = s3_base_uri.into_parts();
-    parts.path_and_query = req.uri().path_and_query().cloned();
-    let uri = match Uri::from_parts(parts) {
-        Ok(uri) => {
-            debug!("Constructed URI: {}", uri);
-            uri
-        }
+    let uri = match construct_uri(&s3_base_uri, req.uri()) {
+        Ok(uri) => uri,
         Err(e) => {
-            error!("Failed to build URI: {}", e);
-            let mut response = Response::new(Body::from("Internal Server Error"));
-            *response.status_mut() = hyper::StatusCode::INTERNAL_SERVER_ERROR;
-            return Ok(response);
+            error!("Failed to construct URI: {}", e);
+            return Ok(Response::builder()
+                .status(hyper::StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Body::from("Internal Server Error"))
+                .unwrap());
         }
     };
 
-    *req.uri_mut() = uri;
-    req.headers_mut().remove("host");
+    let method = req.method().clone();
+    let headers = req.headers().clone();
+    let body_bytes = to_bytes(req.into_body()).await?;
 
-    match client.request(req).await {
-        Ok(resp) => {
-            let duration = start.elapsed();
-            let status = resp.status();
-            info!(
-                "Request to S3 successful: status {}, duration {:?}",
-                status, duration
-            );
+    for retry in 0..MAX_RETRIES {
+        let mut new_req = Request::builder()
+            .method(method.clone())
+            .uri(uri.clone());
 
-            debug!("Response headers: {:?}", resp.headers());
-
-            Ok(resp)
+        for (name, value) in headers.iter() {
+            if name != "host" {
+                new_req = new_req.header(name, value);
+            }
         }
-        Err(e) => {
-            let duration = start.elapsed();
-            error!(
-                "Error forwarding request to S3: {}, duration {:?}",
-                e, duration
-            );
-            let mut response = Response::new(Body::from("Bad Gateway"));
-            *response.status_mut() = hyper::StatusCode::BAD_GATEWAY;
-            Ok(response)
+
+        let new_req = new_req.body(Body::from(body_bytes.clone())).expect("Failed to build request");
+
+        debug!("Sending request to S3: {:?}", new_req);
+        match timeout(REQUEST_TIMEOUT, client.request(new_req)).await {
+            Ok(Ok(resp)) => {
+                let status = resp.status();
+                info!("Response from S3: status {}", status);
+                debug!("Response headers: {:?}", resp.headers());
+                return Ok(resp);
+            }
+            Ok(Err(e)) => {
+                error!(
+                    "Error forwarding request to S3: {}, retry: {}",
+                    e, retry
+                );
+                if retry < MAX_RETRIES - 1 {
+                    let backoff = 2u64.pow(retry) * 1000 + rand::thread_rng().gen_range(0..1000);
+                    tokio::time::sleep(Duration::from_millis(backoff)).await;
+                } else {
+                    return Ok(Response::builder()
+                        .status(hyper::StatusCode::BAD_GATEWAY)
+                        .body(Body::from("Bad Gateway"))
+                        .unwrap());
+                }
+            }
+            Err(_) => {
+                warn!("Request to S3 timed out, retry: {}", retry);
+                if retry == MAX_RETRIES - 1 {
+                    return Ok(Response::builder()
+                        .status(hyper::StatusCode::GATEWAY_TIMEOUT)
+                        .body(Body::from("Gateway Timeout"))
+                        .unwrap());
+                }
+            }
         }
     }
+
+    unreachable!()
+}
+
+fn construct_uri(base_uri: &Uri, request_uri: &Uri) -> Result<Uri, hyper::http::Error> {
+    let mut parts = base_uri.clone().into_parts();
+    let path = request_uri.path();
+    let query = request_uri.query().map(|q| format!("?{}", q)).unwrap_or_default();
+    parts.path_and_query = Some(format!("{}{}", path, query).parse().unwrap());
+    Uri::from_parts(parts).map_err(|e| hyper::http::Error::from(e))
+}
+
+fn is_valid_s3_request(_req: &Request<Body>) -> bool {
+    // Implement your S3 request validation logic here
+    // For example, check if the path starts with a valid bucket name
+    // or if the request contains required S3 headers
+    true // Placeholder
 }


### PR DESCRIPTION
- add connectiong draining
- add no ssl checking
- add retry mechanism
- improve full request header and body cloning

TODO: try to fix handling F5 / refresh in browser; sometimes the connection is not properly closed in the proxy before the request is handled. Its not a big issue, but an annoying warning